### PR TITLE
[adaptation-oneplus-oneplus6] Enable feedbackd@leds-sysfs by default

### DIFF
--- a/debian/adaptation-oneplus-oneplus6-configs.install
+++ b/debian/adaptation-oneplus-oneplus6-configs.install
@@ -1,1 +1,2 @@
-sparse/* /
+usr/* /usr
+etc/* /etc

--- a/debian/adaptation-oneplus-oneplus6-configs.links
+++ b/debian/adaptation-oneplus-oneplus6-configs.links
@@ -1,0 +1,3 @@
+/usr/lib/adaptation-oneplus-oneplus6/sources.list.d/op6-leds.list /etc/apt/sources.list.d/op6-leds.list
+/usr/lib/adaptation-oneplus-oneplus6/preferences.d/30-op6-leds /etc/apt/preferences.d/30-op6-leds
+/usr/lib/adaptation-oneplus-oneplus6/package-sideload-create.d/op6-leds /etc/package-sideload-create.d/op6-leds

--- a/usr/lib/adaptation-oneplus-oneplus6/package-sideload-create.d/op6-leds
+++ b/usr/lib/adaptation-oneplus-oneplus6/package-sideload-create.d/op6-leds
@@ -1,0 +1,4 @@
+feedbackd
+feedbackd-common
+gir1.2-lfb-0.0
+libfeedback-dev 

--- a/usr/lib/adaptation-oneplus-oneplus6/preferences.d/30-op6-leds
+++ b/usr/lib/adaptation-oneplus-oneplus6/preferences.d/30-op6-leds
@@ -1,3 +1,3 @@
 Package: feedbackd feedbackd-common gir1.2-lfb-0.0 libfeedback-dev 
-Pin: release l=Droidian\ (droidian-feedbackd-trixie-op6-leds\ channel)
+Pin: release l=Droidian\ (droidian-feedbackd-trixie-leds-sysfs\ channel)
 Pin-Priority: 1003

--- a/usr/lib/adaptation-oneplus-oneplus6/sources.list.d/op6-leds.list
+++ b/usr/lib/adaptation-oneplus-oneplus6/sources.list.d/op6-leds.list
@@ -1,1 +1,1 @@
-deb http://droidian-feedbackd.repo.droidian.org/trixie-op6-leds/ trixie main
+deb http://droidian-feedbackd.repo.droidian.org/trixie-leds-sysfs/ trixie main


### PR DESCRIPTION
This PR adds @FakeShell 's `leds-sysfs` branch by default in the adaptation.

This works both when building the adaptation bundle and standard images.

Tested fine on enchilada.